### PR TITLE
Keyboard controller support

### DIFF
--- a/src/cli/stella/SystemConfigSetupProvider.ts
+++ b/src/cli/stella/SystemConfigSetupProvider.ts
@@ -28,7 +28,7 @@ import CommandInterpreter from '../CommandInterpreter';
 import Factory from '../../machine/cpu/Factory';
 
 export default class SystemConfigSetupProvider {
-    constructor(private _config: Config) {}
+    constructor(private _config: Config) { }
 
     getCommands(): CommandInterpreter.CommandTableInterface {
         return this._commands;
@@ -67,12 +67,52 @@ export default class SystemConfigSetupProvider {
         return `audio ${this._config.enableAudio ? 'enabled' : 'disabled'}`;
     }
 
-    protected _setupPaddles(args?: Array<string>) {
+    protected _setupControllerPort0(args?: Array<string>) {
         if (args && args.length !== 0) {
-            this._config.emulatePaddles = this._isArgTruthy(args[0]);
+            this._config.controllerPort0 = this._parseControllerType(args[0]);
         }
 
-        return `paddle emulation: ${this._config.emulatePaddles ? 'enabled' : 'disabled'}`;
+        return `current controller port 0: ${this._humanReadableControllerType(this._config.controllerPort0)}`;
+    }
+
+    protected _setupControllerPort1(args?: Array<string>) {
+        if (args && args.length !== 0) {
+            this._config.controllerPort1 = this._parseControllerType(args[0]);
+        }
+
+        return `current controller port 1: ${this._humanReadableControllerType(this._config.controllerPort1)}`;
+    }
+
+    protected _parseControllerType(value: string) {
+        switch (value.toLowerCase()) {
+            case 'joystick':
+                return Config.ControllerType.joystick;
+
+            case 'paddles':
+                return Config.ControllerType.paddles;
+
+            case 'keypad':
+                return Config.ControllerType.keypad;
+
+            default:
+                throw new Error(`invalid controller type "${value}"`);
+        }
+    }
+
+    protected _humanReadableControllerType(controllerType: Config.ControllerType) {
+        switch (controllerType) {
+            case Config.ControllerType.joystick:
+                return 'joystick';
+
+            case Config.ControllerType.paddles:
+                return 'paddles';
+
+            case Config.ControllerType.keypad:
+                return 'keypad';
+
+            default:
+                throw new Error(`invalid controller type "${controllerType}"`);
+        }
     }
 
     protected _setHighPrecisionCpu(args?: Array<string>) {
@@ -112,7 +152,7 @@ export default class SystemConfigSetupProvider {
             this._config.pcmAudio = this._isArgTruthy(args[0]);
         }
 
-        return `PCM audio emulation: ${this._config.emulatePaddles ? 'enabled' : 'disabled'}`;
+        return `PCM audio emulation: ${this._config.pcmAudio ? 'enabled' : 'disabled'}`;
     }
 
     protected _isArgTruthy(arg: string): boolean {
@@ -124,7 +164,8 @@ export default class SystemConfigSetupProvider {
     _commands: CommandInterpreter.CommandTableInterface = {
         'tv-mode': this._setupVideo.bind(this),
         audio: this._setupAudio.bind(this),
-        paddles: this._setupPaddles.bind(this),
+        'controller-port-0': this._setupControllerPort0.bind(this),
+        'controller-port-1': this._setupControllerPort1.bind(this),
         seed: this._setRandomSeed.bind(this),
         pcm: this._setupPcmAUdio.bind(this),
         'high-precision-cpu': this._setHighPrecisionCpu.bind(this)

--- a/src/cli/stella/SystemConfigSetupProvider.ts
+++ b/src/cli/stella/SystemConfigSetupProvider.ts
@@ -28,7 +28,7 @@ import CommandInterpreter from '../CommandInterpreter';
 import Factory from '../../machine/cpu/Factory';
 
 export default class SystemConfigSetupProvider {
-    constructor(private _config: Config) {}
+    constructor(private _config: Config) { }
 
     getCommands(): CommandInterpreter.CommandTableInterface {
         return this._commands;

--- a/src/cli/stella/SystemConfigSetupProvider.ts
+++ b/src/cli/stella/SystemConfigSetupProvider.ts
@@ -28,7 +28,7 @@ import CommandInterpreter from '../CommandInterpreter';
 import Factory from '../../machine/cpu/Factory';
 
 export default class SystemConfigSetupProvider {
-    constructor(private _config: Config) { }
+    constructor(private _config: Config) {}
 
     getCommands(): CommandInterpreter.CommandTableInterface {
         return this._commands;

--- a/src/frontend/elm/Stellerator/Main.elm.d.ts
+++ b/src/frontend/elm/Stellerator/Main.elm.d.ts
@@ -112,7 +112,6 @@ export interface Cartridge {
     name: string;
     cartridgeType: CartridgeInfo.CartridgeType;
     tvMode: TvMode;
-    emulatePaddles: boolean;
     controllerPort0: ControllerType;
     controllerPort1: ControllerType;
     volume: number;

--- a/src/frontend/elm/Stellerator/Main.elm.d.ts
+++ b/src/frontend/elm/Stellerator/Main.elm.d.ts
@@ -81,6 +81,12 @@ export const enum Scaling {
     none = 'none',
 }
 
+export const enum ControllerType {
+    joystick = 'joystick',
+    paddles = 'paddles',
+    keypad = 'keypad',
+}
+
 export interface EmulationStateStopped {
     state: EmulationStateKey.stopped;
 }
@@ -107,6 +113,8 @@ export interface Cartridge {
     cartridgeType: CartridgeInfo.CartridgeType;
     tvMode: TvMode;
     emulatePaddles: boolean;
+    controllerPort0: ControllerType;
+    controllerPort1: ControllerType;
     volume: number;
     rngSeed?: number;
     firstVisibleLine?: number;

--- a/src/frontend/elm/Stellerator/Model.elm
+++ b/src/frontend/elm/Stellerator/Model.elm
@@ -33,6 +33,7 @@ module Stellerator.Model exposing
     , ChangeSettingsMsg(..)
     , ColorSwitch(..)
     , ConsoleSwitches
+    , ControllerType(..)
     , CpuEmulation(..)
     , DifficultySwitch(..)
     , EmulationState(..)
@@ -51,6 +52,7 @@ module Stellerator.Model exposing
     , decodeAudioEmulation
     , decodeCartridge
     , decodeCartridgeType
+    , decodeControllerType
     , decodeCpuEmulation
     , decodeEmulationState
     , decodeInputDriverEvent
@@ -139,12 +141,20 @@ type Scaling
     | ScalingNone
 
 
+type ControllerType
+    = ControllerTypeJoystick
+    | ControllerTypePaddles
+    | ControllerTypeKeypad
+
+
 type alias Cartridge =
     { hash : String
     , name : String
     , cartridgeType : String
     , tvMode : TvMode
     , emulatePaddles : Bool
+    , controllerPort0 : ControllerType
+    , controllerPort1 : ControllerType
     , volume : Int
     , rngSeed : Maybe Int
     , firstVisibleLine : Maybe Int
@@ -246,6 +256,8 @@ type ChangeCartridgeMsg
     | ChangeCartridgeType String
     | ChangeCartridgeTvMode TvMode
     | ChangeCartridgeEmulatePaddles Bool
+    | ChangeCartridgeControllerPort0 ControllerType
+    | ChangeCartridgeControllerPort1 ControllerType
     | ChangeCartridgeRngSeed (Maybe Int)
     | ChangeCartridgeFirstVisibleLine (Maybe Int)
     | ChangeCartridgeCpuEmulation (Maybe CpuEmulation)
@@ -600,6 +612,36 @@ encodeScaling scaling =
         ScalingNone ->
             Encode.string "none"
 
+decodeControllerType : Decode.Decoder ControllerType
+decodeControllerType =
+    Decode.string
+        |> Decode.andThen
+            (\s ->
+                case s of
+                    "joystick" ->
+                        Decode.succeed ControllerTypeJoystick
+
+                    "paddles" ->
+                        Decode.succeed ControllerTypePaddles
+
+                    "keypad" ->
+                        Decode.succeed ControllerTypeKeypad
+
+                    _ ->
+                        Decode.fail "invalid controller value"
+            )
+
+encodeControllerType : ControllerType -> Encode.Value
+encodeControllerType scaling =
+    case scaling of
+        ControllerTypeJoystick ->
+            Encode.string "joystick"
+
+        ControllerTypePaddles ->
+            Encode.string "paddles"
+
+        ControllerTypeKeypad ->
+            Encode.string "keypad"
 
 decodeSettings : Decode.Decoder Settings
 decodeSettings =
@@ -646,6 +688,8 @@ decodeCartridge =
         |> Pipeline.required "cartridgeType" Decode.string
         |> Pipeline.required "tvMode" decodeTvMode
         |> Pipeline.required "emulatePaddles" Decode.bool
+        |> Pipeline.required "controllerPort0" decodeControllerType
+        |> Pipeline.required "controllerPort1" decodeControllerType
         |> Pipeline.required "volume" Decode.int
         |> Pipeline.optional "rngSeed" (Decode.maybe Decode.int) Nothing
         |> Pipeline.optional "firstVisibleLine" (Decode.maybe Decode.int) Nothing
@@ -661,6 +705,8 @@ encodeCartridge cartridge =
     , ( "cartridgeType", Encode.string cartridge.cartridgeType )
     , ( "tvMode", encodeTvMode cartridge.tvMode )
     , ( "emulatePaddles", Encode.bool cartridge.emulatePaddles )
+    , ( "controllerPort0", encodeControllerType cartridge.controllerPort0 )
+    , ( "controllerPort1", encodeControllerType cartridge.controllerPort1 )
     , ( "volume", Encode.int cartridge.volume )
     ]
         |> encodeOptional "rngSeed" Encode.int cartridge.rngSeed

--- a/src/frontend/elm/Stellerator/Model.elm
+++ b/src/frontend/elm/Stellerator/Model.elm
@@ -152,7 +152,6 @@ type alias Cartridge =
     , name : String
     , cartridgeType : String
     , tvMode : TvMode
-    , emulatePaddles : Bool
     , controllerPort0 : ControllerType
     , controllerPort1 : ControllerType
     , volume : Int
@@ -687,7 +686,6 @@ decodeCartridge =
         |> Pipeline.required "name" Decode.string
         |> Pipeline.required "cartridgeType" Decode.string
         |> Pipeline.required "tvMode" decodeTvMode
-        |> Pipeline.required "emulatePaddles" Decode.bool
         |> Pipeline.required "controllerPort0" decodeControllerType
         |> Pipeline.required "controllerPort1" decodeControllerType
         |> Pipeline.required "volume" Decode.int
@@ -704,7 +702,6 @@ encodeCartridge cartridge =
     , ( "name", Encode.string cartridge.name )
     , ( "cartridgeType", Encode.string cartridge.cartridgeType )
     , ( "tvMode", encodeTvMode cartridge.tvMode )
-    , ( "emulatePaddles", Encode.bool cartridge.emulatePaddles )
     , ( "controllerPort0", encodeControllerType cartridge.controllerPort0 )
     , ( "controllerPort1", encodeControllerType cartridge.controllerPort1 )
     , ( "volume", Encode.int cartridge.volume )

--- a/src/frontend/elm/Stellerator/Model.elm
+++ b/src/frontend/elm/Stellerator/Model.elm
@@ -254,7 +254,6 @@ type ChangeCartridgeMsg
     = ChangeCartridgeName String
     | ChangeCartridgeType String
     | ChangeCartridgeTvMode TvMode
-    | ChangeCartridgeEmulatePaddles Bool
     | ChangeCartridgeControllerPort0 ControllerType
     | ChangeCartridgeControllerPort1 ControllerType
     | ChangeCartridgeRngSeed (Maybe Int)

--- a/src/frontend/elm/Stellerator/Update.elm
+++ b/src/frontend/elm/Stellerator/Update.elm
@@ -51,9 +51,6 @@ updateCartridge cartridgeTypes msg cartridge =
         ChangeCartridgeTvMode tvMode ->
             { cartridge | tvMode = tvMode }
 
-        ChangeCartridgeEmulatePaddles emulatePaddles ->
-            { cartridge | emulatePaddles = emulatePaddles }
-
         ChangeCartridgeControllerPort0 controllerPort0 ->
             { cartridge | controllerPort0 = controllerPort0 }
 

--- a/src/frontend/elm/Stellerator/Update.elm
+++ b/src/frontend/elm/Stellerator/Update.elm
@@ -54,6 +54,12 @@ updateCartridge cartridgeTypes msg cartridge =
         ChangeCartridgeEmulatePaddles emulatePaddles ->
             { cartridge | emulatePaddles = emulatePaddles }
 
+        ChangeCartridgeControllerPort0 controllerPort0 ->
+            { cartridge | controllerPort0 = controllerPort0 }
+
+        ChangeCartridgeControllerPort1 controllerPort1 ->
+            { cartridge | controllerPort1 = controllerPort1 }
+
         ChangeCartridgeRngSeed seed ->
             let
                 newSeed =

--- a/src/frontend/elm/Stellerator/View/Cartridges.elm
+++ b/src/frontend/elm/Stellerator/View/Cartridges.elm
@@ -42,6 +42,7 @@ import Stellerator.Model
         , Cartridge
         , CartridgeViewMode(..)
         , ChangeCartridgeMsg(..)
+        , ControllerType(..)
         , CpuEmulation(..)
         , Media(..)
         , Model
@@ -194,6 +195,18 @@ settingsItems model cart =
             cart.tvMode
     , checkbox "Emulate paddles:" <|
         Form.checkbox (changeCartridge ChangeCartridgeEmulatePaddles) cart.emulatePaddles
+    , oneline "Controller Port 0:" <|
+        Form.radioGroup
+            []
+            [ ( ControllerTypeJoystick, "Joystick" ), ( ControllerTypePaddles, "Paddles" ), ( ControllerTypeKeypad, "Keypad" ) ]
+            (changeCartridge ChangeCartridgeControllerPort0)
+            cart.controllerPort0
+    , oneline "Controller Port 1:" <|
+        Form.radioGroup
+            []
+            [ ( ControllerTypeJoystick, "Joystick" ), ( ControllerTypePaddles, "Paddles" ), ( ControllerTypeKeypad, "Keypad" ) ]
+            (changeCartridge ChangeCartridgeControllerPort1)
+            cart.controllerPort1
     , oneline "RNG seed:" <| optionalNumberInput ChangeCartridgeRngSeed cart.rngSeed
     , oneline "First visible line:" <| optionalNumberInput ChangeCartridgeFirstVisibleLine cart.firstVisibleLine
     , oneline "CPU emulation:" <|

--- a/src/frontend/elm/Stellerator/View/Cartridges.elm
+++ b/src/frontend/elm/Stellerator/View/Cartridges.elm
@@ -193,8 +193,6 @@ settingsItems model cart =
             [ ( TvPAL, "PAL" ), ( TvNTSC, "NTSC" ), ( TvSECAM, "SECAM" ) ]
             (changeCartridge ChangeCartridgeTvMode)
             cart.tvMode
-    , checkbox "Emulate paddles:" <|
-        Form.checkbox (changeCartridge ChangeCartridgeEmulatePaddles) cart.emulatePaddles
     , oneline "Controller Port 0:" <|
         Form.radioGroup
             []

--- a/src/frontend/stellerator/service/AddCartridge.ts
+++ b/src/frontend/stellerator/service/AddCartridge.ts
@@ -117,7 +117,6 @@ class AddCartridge {
                 name,
                 tvMode,
                 cartridgeType,
-                emulatePaddles: false,
                 controllerPort0: ControllerType.joystick,
                 controllerPort1: ControllerType.joystick,
                 volume: 100,

--- a/src/frontend/stellerator/service/AddCartridge.ts
+++ b/src/frontend/stellerator/service/AddCartridge.ts
@@ -25,14 +25,14 @@
 
 import { injectable, inject } from 'inversify';
 import JSZip from '@progress/jszip-esm';
-import { Ports, TvMode } from '../../elm/Stellerator/Main.elm';
+import { ControllerType, Ports, TvMode } from '../../elm/Stellerator/Main.elm';
 import { calculateFromUint8Array as md5sum } from '../../../tools/hash/md5';
 import CartridgeDetector from '../../../machine/stella/cartridge/CartridgeDetector';
 import Storage, { CartridgeWithImage } from './Storage';
 
 @injectable()
 class AddCartridge {
-    constructor(@inject(Storage) private _storage: Storage) {}
+    constructor(@inject(Storage) private _storage: Storage) { }
 
     init(ports: Ports): void {
         this._ports = ports;
@@ -118,6 +118,8 @@ class AddCartridge {
                 tvMode,
                 cartridgeType,
                 emulatePaddles: false,
+                controllerPort0: ControllerType.joystick,
+                controllerPort1: ControllerType.joystick,
                 volume: 100,
             },
             image: content,

--- a/src/frontend/stellerator/service/Emulation.ts
+++ b/src/frontend/stellerator/service/Emulation.ts
@@ -390,7 +390,12 @@ class Emulation {
 
         this._driverManager
             .addDriver(this._keyboardDriver, (context, driver: KeyboardDriver) =>
-                driver.bind(context.getJoystick(0), context.getJoystick(1), context.getControlPanel())
+                driver.bind(
+                    context.getJoystick(0),
+                    context.getJoystick(1),
+                    context.getKeypad(0),
+                    context.getKeypad(1),
+                    context.getControlPanel())
             )
             .addDriver(this._paddleDriver, (context, driver: MouseAsPaddleDriver) => driver.bind(context.getPaddle(0)));
     }

--- a/src/frontend/stellerator/service/Emulation.ts
+++ b/src/frontend/stellerator/service/Emulation.ts
@@ -319,6 +319,14 @@ class Emulation {
 
         this._currentConfig = config(cartidge, settings);
 
+        this._keyboardDriver.remap(KeyboardDriver.defaultMappings);
+        if (this._currentConfig.controllerPort0 === Config.ControllerType.keypad) {
+            this._keyboardDriver.overlay(KeyboardDriver.keypad0Mappings);
+        }
+        if (this._currentConfig.controllerPort1 === Config.ControllerType.keypad) {
+            this._keyboardDriver.overlay(KeyboardDriver.keypad1Mappings);
+        }
+
         await this._emulationService.start(image, this._currentConfig, cartidge.cartridgeType);
 
         this._updateConsoleSwitches(switches);

--- a/src/frontend/stellerator/service/Emulation.ts
+++ b/src/frontend/stellerator/service/Emulation.ts
@@ -42,6 +42,7 @@ import {
     StartEmulationPayload,
     TvEmulation,
     Scaling,
+    ControllerType,
 } from '../../elm/Stellerator/Main.elm';
 
 import EmulationServiceInterface from '../../../web/stella/service/EmulationServiceInterface';
@@ -100,6 +101,22 @@ function tvMode(cartridge: Cartridge): Config.TvMode {
     }
 }
 
+function controllerType(controllerType: ControllerType): Config.ControllerType {
+    switch (controllerType) {
+        case ControllerType.joystick:
+            return Config.ControllerType.joystick;
+
+        case ControllerType.paddles:
+            return Config.ControllerType.paddles;
+
+        case ControllerType.keypad:
+            return Config.ControllerType.keypad;
+
+        default:
+            throw new Error(`cannot happen: invalid controller type ${controllerType}`);
+    }
+}
+
 function config(cartridge: Cartridge, settings: Settings): Config {
     return {
         tvMode: tvMode(cartridge),
@@ -109,6 +126,8 @@ function config(cartridge: Cartridge, settings: Settings): Config {
         frameStart: typeof cartridge.firstVisibleLine === 'undefined' ? -1 : cartridge.firstVisibleLine,
         pcmAudio: (cartridge.audioEmulation || settings.audioEmulation) === AudioEmulation.pcm,
         cpuType: cpuType(cartridge, settings),
+        controllerPort0: controllerType(cartridge.controllerPort0),
+        controllerPort1: controllerType(cartridge.controllerPort1),
     };
 }
 

--- a/src/frontend/stellerator/service/Emulation.ts
+++ b/src/frontend/stellerator/service/Emulation.ts
@@ -122,7 +122,6 @@ function config(cartridge: Cartridge, settings: Settings): Config {
         tvMode: tvMode(cartridge),
         enableAudio: cartridge.volume * settings.volume > 0,
         randomSeed: typeof cartridge.rngSeed === 'undefined' ? -1 : cartridge.rngSeed,
-        emulatePaddles: cartridge.emulatePaddles,
         frameStart: typeof cartridge.firstVisibleLine === 'undefined' ? -1 : cartridge.firstVisibleLine,
         pcmAudio: (cartridge.audioEmulation || settings.audioEmulation) === AudioEmulation.pcm,
         cpuType: cpuType(cartridge, settings),

--- a/src/frontend/stellerator/service/Storage.ts
+++ b/src/frontend/stellerator/service/Storage.ts
@@ -24,7 +24,7 @@
  */
 
 import Dexie from 'dexie';
-import { Cartridge, Settings, TvEmulation, Scaling } from '../../elm/Stellerator/Main.elm';
+import { Cartridge, Settings, TvEmulation, Scaling, ControllerType } from '../../elm/Stellerator/Main.elm';
 import { injectable } from 'inversify';
 
 export interface CartridgeWithImage {
@@ -84,6 +84,33 @@ class Database extends Dexie {
                     .toCollection()
                     .modify((cartridge) => {
                         delete (cartridge as any).phosphorEmulation;
+                    });
+            });
+
+
+        this.version(3)
+            .stores({
+                cartridges: '&hash',
+                roms: '&hash',
+                settings: '&id',
+            })
+            .upgrade((transaction) => {
+
+                transaction
+                    .table<Cartridge>('cartridges')
+                    .toCollection()
+                    .modify((cartridge) => {
+                        const _cartridge = cartridge as any;
+
+                        const controllerType = _cartridge.emulatePaddles ?
+                            ControllerType.paddles :
+                            ControllerType.joystick;
+
+                        delete _cartridge.emulatePaddles;
+
+                        _cartridge.controllerPort0 = controllerType;
+                        _cartridge.controllerPort1 = controllerType;
+
                     });
             });
     }

--- a/src/machine/io/KeypadController.ts
+++ b/src/machine/io/KeypadController.ts
@@ -23,38 +23,22 @@
  *   SOFTWARE.
  */
 
-interface ControlState {
-    joystickState: Array<ControlState.JoystickState>;
-    keypadState: Array<ControlState.KeypadState>;
-    paddleState: Array<ControlState.PaddleState>;
-    controlPanelState: ControlState.ControlPanelState;
+import Switch from './Switch';
+import SwitchInterface from './SwitchInterface';
+import KeypadControllerInterface from './KeypadControllerInterface';
+
+export default class KeypadController implements KeypadControllerInterface {
+
+    constructor() {
+        for (let i = 0; i < 4; i++) {
+            this._rows[i] = new Array<Switch>(3);
+        }
+    }
+
+    getKey(row: number, column: number): SwitchInterface {
+        return this._rows[row][column];
+    }
+
+    private _rows = new Array<Array<Switch>>(4);
+
 }
-
-namespace ControlState {
-    export interface JoystickState {
-        left: boolean;
-        right: boolean;
-        up: boolean;
-        down: boolean;
-        fire: boolean;
-    }
-
-    export interface KeypadState {
-        rows: Array<Array<boolean>>;
-    }
-
-    export interface PaddleState {
-        value: number;
-        fire: boolean;
-    }
-
-    export interface ControlPanelState {
-        difficulty0: boolean;
-        difficulty1: boolean;
-        select: boolean;
-        reset: boolean;
-        color: boolean;
-    }
-}
-
-export { ControlState as default };

--- a/src/machine/io/KeypadController.ts
+++ b/src/machine/io/KeypadController.ts
@@ -30,13 +30,16 @@ import KeypadControllerInterface from './KeypadControllerInterface';
 export default class KeypadController implements KeypadControllerInterface {
 
     constructor() {
-        for (let i = 0; i < 4; i++) {
-            this._rows[i] = new Array<Switch>(3);
+        for (let row = 0; row < 4; row++) {
+            this._rows[row] = new Array<Switch>(3);
+            for (let col = 0; col < 3; col++) {
+                this._rows[row][col] = new Switch();
+            }
         }
     }
 
-    getKey(row: number, column: number): SwitchInterface {
-        return this._rows[row][column];
+    getKey(row: number, col: number): SwitchInterface {
+        return this._rows[row][col];
     }
 
     private _rows = new Array<Array<Switch>>(4);

--- a/src/machine/io/KeypadControllerInterface.ts
+++ b/src/machine/io/KeypadControllerInterface.ts
@@ -23,38 +23,12 @@
  *   SOFTWARE.
  */
 
-interface ControlState {
-    joystickState: Array<ControlState.JoystickState>;
-    keypadState: Array<ControlState.KeypadState>;
-    paddleState: Array<ControlState.PaddleState>;
-    controlPanelState: ControlState.ControlPanelState;
+import SwitchInterface from './SwitchInterface';
+
+interface KeypadControllerInterface {
+
+    getKey(row: number, column: number): SwitchInterface;
+
 }
 
-namespace ControlState {
-    export interface JoystickState {
-        left: boolean;
-        right: boolean;
-        up: boolean;
-        down: boolean;
-        fire: boolean;
-    }
-
-    export interface KeypadState {
-        rows: Array<Array<boolean>>;
-    }
-
-    export interface PaddleState {
-        value: number;
-        fire: boolean;
-    }
-
-    export interface ControlPanelState {
-        difficulty0: boolean;
-        difficulty1: boolean;
-        select: boolean;
-        reset: boolean;
-        color: boolean;
-    }
-}
-
-export { ControlState as default };
+export { KeypadControllerInterface as default };

--- a/src/machine/stella/Board.ts
+++ b/src/machine/stella/Board.ts
@@ -79,7 +79,7 @@ class Board implements BoardInterface {
             paddles[i] = new Paddle();
         }
 
-        for (let i = 0; i < 4; i++) {
+        for (let i = 0; i < 2; i++) {
             keypadControllers[i] = new KeypadController();
         }
 

--- a/src/machine/stella/Board.ts
+++ b/src/machine/stella/Board.ts
@@ -86,7 +86,7 @@ class Board implements BoardInterface {
         const keypads = new KeypadsReader(keypadControllers);
 
         const cpu = cpuFactory(bus, this._rng);
-        const pia = new Pia(controlPanel, joystick0, joystick1, keypads, this._rng);
+        const pia = new Pia(_config, controlPanel, joystick0, joystick1, paddles, keypads, this._rng);
         const tia = new Tia(_config, joystick0, joystick1, paddles, keypads);
 
         cpu.setInvalidInstructionCallback(() => this._onInvalidInstruction());

--- a/src/machine/stella/Board.ts
+++ b/src/machine/stella/Board.ts
@@ -41,6 +41,9 @@ import ControlPanel from './ControlPanel';
 import ControlPanelInterface from './ControlPanelInterface';
 import DigitalJoystickInterface from '../io/DigitalJoystickInterface';
 import DigitalJoystick from '../io/DigitalJoystick';
+import KeypadControllerInterface from '../io/KeypadControllerInterface';
+import KeypadController from '../io/KeypadController';
+import KeypadsReader from './KeypadsReader';
 import PaddleInterface from '../io/PaddleInterface';
 import Paddle from '../io/Paddle';
 
@@ -69,17 +72,26 @@ class Board implements BoardInterface {
         const controlPanel = new ControlPanel(),
             joystick0 = new DigitalJoystick(),
             joystick1 = new DigitalJoystick(),
-            paddles = new Array(4);
+            paddles = new Array(4),
+            keypadControllers = new Array(2);
 
         for (let i = 0; i < 4; i++) {
             paddles[i] = new Paddle();
         }
 
+        for (let i = 0; i < 4; i++) {
+            keypadControllers[i] = new KeypadController();
+        }
+
+        const keypads = new KeypadsReader(keypadControllers);
+
         const cpu = cpuFactory(bus, this._rng);
-        const pia = new Pia(controlPanel, joystick0, joystick1, this._rng);
-        const tia = new Tia(_config, joystick0, joystick1, paddles);
+        const pia = new Pia(controlPanel, joystick0, joystick1, keypads, this._rng);
+        const tia = new Tia(_config, joystick0, joystick1, paddles, keypads);
 
         cpu.setInvalidInstructionCallback(() => this._onInvalidInstruction());
+
+        keypads.setCpuTimeProvider(() => this.getCpuTime());
 
         tia.setCpu(cpu)
             .setBus(bus)
@@ -104,6 +116,8 @@ class Board implements BoardInterface {
         this._joystick0 = joystick0;
         this._joystick1 = joystick1;
         this._paddles = paddles;
+        this._keypad0 = keypadControllers[0];
+        this._keypad1 = keypadControllers[1];
 
         this._bus.event.trap.addHandler((payload: Bus.TrapPayload) =>
             this.triggerTrap(BoardInterface.TrapReason.bus, payload.message)
@@ -226,6 +240,14 @@ class Board implements BoardInterface {
 
     getJoystick1(): DigitalJoystickInterface {
         return this._joystick1;
+    }
+
+    getKeypad0(): KeypadControllerInterface {
+        return this._keypad0;
+    }
+
+    getKeypad1(): KeypadControllerInterface {
+        return this._keypad1;
     }
 
     getBoardStateDebug(): string {
@@ -374,6 +396,8 @@ class Board implements BoardInterface {
     private _controlPanel: ControlPanel;
     private _joystick0: DigitalJoystick;
     private _joystick1: DigitalJoystick;
+    private _keypad0: KeypadController;
+    private _keypad1: KeypadController;
     private _paddles: Array<Paddle>;
 
     private _runTask: TaskInterface;

--- a/src/machine/stella/Bus.ts
+++ b/src/machine/stella/Bus.ts
@@ -125,8 +125,19 @@ class Bus implements BusInterface {
         }
     }
 
-    // Stub
-    poke(address: number, value: number) {}
+    poke(address: number, value: number) {
+        address &= 0x1fff;
+
+        // Chip select A12 -> cartridge
+        if (address & 0x1000) {
+            return this._cartridge.write(address, value);
+        } else if (address & 0x80) {
+            // Chip select A7 -> PIA
+            return this._pia.write(address, value);
+        } else {
+            return this._tia.write(address, value);
+        }
+    }
 
     getLastDataBusValue(): number {
         return this._lastDataBusValue;
@@ -177,7 +188,7 @@ namespace Bus {
     }
 
     export class TrapPayload {
-        constructor(public reason: TrapReason, public bus: Bus, public message?: string) {}
+        constructor(public reason: TrapReason, public bus: Bus, public message?: string) { }
     }
 }
 

--- a/src/machine/stella/Config.ts
+++ b/src/machine/stella/Config.ts
@@ -29,7 +29,6 @@ interface Config {
     tvMode: Config.TvMode;
     enableAudio: boolean;
     randomSeed: number;
-    emulatePaddles: boolean;
     frameStart: number;
     pcmAudio: boolean;
     cpuType: CpuFactory.Type;
@@ -55,7 +54,6 @@ namespace Config {
             tvMode: TvMode.ntsc,
             enableAudio: true,
             randomSeed: -1,
-            emulatePaddles: true,
             frameStart: -1,
             pcmAudio: false,
             cpuType: CpuFactory.Type.stateMachine,

--- a/src/machine/stella/Config.ts
+++ b/src/machine/stella/Config.ts
@@ -33,6 +33,8 @@ interface Config {
     frameStart: number;
     pcmAudio: boolean;
     cpuType: CpuFactory.Type;
+    controllerPort0: Config.ControllerType;
+    controllerPort1: Config.ControllerType;
 }
 
 namespace Config {
@@ -40,6 +42,12 @@ namespace Config {
         ntsc,
         pal,
         secam
+    }
+
+    export const enum ControllerType {
+        joystick,
+        paddles,
+        keypad
     }
 
     export function create(config: Partial<Config> = {}): Config {
@@ -51,6 +59,8 @@ namespace Config {
             frameStart: -1,
             pcmAudio: false,
             cpuType: CpuFactory.Type.stateMachine,
+            controllerPort0: ControllerType.joystick,
+            controllerPort1: ControllerType.joystick,
 
             ...config
         };

--- a/src/machine/stella/KeypadsReader.ts
+++ b/src/machine/stella/KeypadsReader.ts
@@ -25,7 +25,7 @@
 
 import KeypadController from '../io/KeypadController';
 
-const PROBE_DELAY = 400;
+const PROBE_DELAY = 0.0004; // 400 microseconds
 
 export default class KeypadsReader {
 
@@ -64,12 +64,12 @@ export default class KeypadsReader {
         let s = (currentTimestamp >= this._returnTimestamp) ? this._swcha_out : 0;
 
         let state = false;
-        for (let pad = 0; pad < 2; pad++) {
+        for (let pad = 1; pad >= 0; pad--) {
             for (let row = 0; row < 4; row++) {
-                if (0 === (s & 0x01)) {
-                    continue;
+                if (1 === (s & 0x01)) {
+                    state = state || this._keypads[pad].getKey(row, column).read();
                 }
-                state = state || this._keypads[pad].getKey(row, column).read();
+                s = s >> 1;
             }
 
         }

--- a/src/machine/stella/KeypadsReader.ts
+++ b/src/machine/stella/KeypadsReader.ts
@@ -58,20 +58,18 @@ export default class KeypadsReader {
         this._swacnt = value;
     }
 
-    inpt(column: number): number {
-
+    inpt(pad: number, column: number): number {
         const currentTimestamp = this._cpuTimeProvider();
         let s = (currentTimestamp >= this._returnTimestamp) ? this._swcha_out : 0;
-
+        if (0 === pad) {
+            s = s >> 4;
+        }
         let state = false;
-        for (let pad = 1; pad >= 0; pad--) {
-            for (let row = 0; row < 4; row++) {
-                if (1 === (s & 0x01)) {
-                    state = state || this._keypads[pad].getKey(row, column).read();
-                }
-                s = s >> 1;
+        for (let row = 0; row < 4; row++) {
+            if (1 === (s & 0x01)) {
+                state = state || this._keypads[pad].getKey(row, column).read();
             }
-
+            s = s >> 1;
         }
         return state ? 0 : 0x80;
 

--- a/src/machine/stella/KeypadsReader.ts
+++ b/src/machine/stella/KeypadsReader.ts
@@ -1,0 +1,86 @@
+/*
+ *   This file is part of 6502.ts, an emulator for 6502 based systems built
+ *   in Typescript
+ *
+ *   Copyright (c) 2014 -- 2020 Christian Speckner and contributors
+ *
+ *   Permission is hereby granted, free of charge, to any person obtaining a copy
+ *   of this software and associated documentation files (the "Software"), to deal
+ *   in the Software without restriction, including without limitation the rights
+ *   to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ *   copies of the Software, and to permit persons to whom the Software is
+ *   furnished to do so, subject to the following conditions:
+ *
+ *   The above copyright notice and this permission notice shall be included in all
+ *   copies or substantial portions of the Software.
+ *
+ *   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *   IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *   FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ *   AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ *   LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ *   OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ *   SOFTWARE.
+ */
+
+import KeypadController from '../io/KeypadController';
+
+const PROBE_DELAY = 400;
+
+export default class KeypadsReader {
+
+    constructor(private _keypads: Array<KeypadController>) {
+        this.reset();
+    }
+
+    setCpuTimeProvider(provider: () => number): void {
+        this._cpuTimeProvider = provider;
+        this._returnTimestamp = 0;
+    }
+
+    reset(): void {
+        this._swacnt = 0;
+        this._swcha_out = 0;
+        this._returnTimestamp = 0;
+    }
+
+    vblank(value: number): void {
+        // BUGBUG: react to vblank?
+    }
+
+    swcha(value: number): void {
+        this._swcha_out = value & this._swacnt;
+        const currentTimestamp = this._cpuTimeProvider();
+        this._returnTimestamp = currentTimestamp + PROBE_DELAY;
+    }
+
+    swacnt(value: number): void {
+        this._swacnt = value;
+    }
+
+    inpt(column: number): number {
+
+        const currentTimestamp = this._cpuTimeProvider();
+        let s = (currentTimestamp >= this._returnTimestamp) ? this._swcha_out : 0;
+
+        let state = false;
+        for (let pad = 0; pad < 2; pad++) {
+            for (let row = 0; row < 4; row++) {
+                if (0 === (s & 0x01)) {
+                    continue;
+                }
+                state = state || this._keypads[pad].getKey(row, column).read();
+            }
+
+        }
+        return state ? 0 : 0x80;
+
+    }
+
+    private _swacnt = 0;
+    private _swcha_out = 0;
+    private _returnTimestamp = 0;
+
+    private _cpuTimeProvider: () => number = null;
+
+}

--- a/src/machine/stella/KeypadsReader.ts
+++ b/src/machine/stella/KeypadsReader.ts
@@ -49,7 +49,7 @@ export default class KeypadsReader {
     }
 
     swcha(value: number): void {
-        this._swcha_out = value & this._swacnt;
+        this._swcha_out = (~value) & this._swacnt;
         const currentTimestamp = this._cpuTimeProvider();
         this._returnTimestamp = currentTimestamp + PROBE_DELAY;
     }

--- a/src/machine/stella/KeypadsReader.ts
+++ b/src/machine/stella/KeypadsReader.ts
@@ -69,7 +69,7 @@ export default class KeypadsReader {
             if (1 === (s & 0x01)) {
                 state = state || this._keypads[pad].getKey(row, column).read();
             }
-            s = s >> 1;
+            s = s >>> 1;
         }
         return state ? 0 : 0x80;
 

--- a/src/machine/stella/Pia.ts
+++ b/src/machine/stella/Pia.ts
@@ -31,12 +31,16 @@ import Bus from './Bus';
 
 import RngInterface from '../../tools/rng/GeneratorInterface';
 import KeypadsReader from './KeypadsReader';
+import PaddleInterface from '../io/PaddleInterface';
+import Config from './Config';
 
 class Pia {
     constructor(
+        private _config: Config,
         private _controlPanel: ControlPanelInterface,
         private _joystick0: DigitalJoystickInterface,
         private _joystick1: DigitalJoystickInterface,
+        private _paddles: Array<PaddleInterface>,
         private _keypads: KeypadsReader,
         private _rng?: RngInterface
     ) {
@@ -154,16 +158,28 @@ class Pia {
     private _readIo(address: number): number {
         switch (address & 0x0283) {
             case Pia.Registers.swcha:
-                return (
-                    (this._joystick1.getUp().read() ? 0 : 0x01) |
-                    (this._joystick1.getDown().read() ? 0 : 0x02) |
-                    (this._joystick1.getLeft().read() ? 0 : 0x04) |
-                    (this._joystick1.getRight().read() ? 0 : 0x08) |
-                    (this._joystick0.getUp().read() ? 0 : 0x10) |
-                    (this._joystick0.getDown().read() ? 0 : 0x20) |
-                    (this._joystick0.getLeft().read() ? 0 : 0x40) |
-                    (this._joystick0.getRight().read() ? 0 : 0x80)
-                );
+                const port0 =
+                    (this._config.controllerPort0 === Config.ControllerType.paddles) ? (
+                        (this._paddles[1].getFire().read() ? 0 : 0x40) |
+                        (this._paddles[0].getFire().read() ? 0 : 0x80)
+                    ) : (
+                        (this._joystick0.getUp().read() ? 0 : 0x10) |
+                        (this._joystick0.getDown().read() ? 0 : 0x20) |
+                        (this._joystick0.getLeft().read() ? 0 : 0x40) |
+                        (this._joystick0.getRight().read() ? 0 : 0x80)
+                    );
+                const port1 =
+                    (this._config.controllerPort1 === Config.ControllerType.paddles) ? (
+                        (this._paddles[3].getFire().read() ? 0 : 0x04) |
+                        (this._paddles[2].getFire().read() ? 0 : 0x08)
+                    ) : (
+                        (this._joystick1.getUp().read() ? 0 : 0x01) |
+                        (this._joystick1.getDown().read() ? 0 : 0x02) |
+                        (this._joystick1.getLeft().read() ? 0 : 0x04) |
+                        (this._joystick1.getRight().read() ? 0 : 0x08)
+                    );
+
+                return port1 | port0;
 
             case Pia.Registers.swchb:
                 return (

--- a/src/machine/stella/Pia.ts
+++ b/src/machine/stella/Pia.ts
@@ -30,12 +30,14 @@ import DigitalJoystickInterface from '../io/DigitalJoystickInterface';
 import Bus from './Bus';
 
 import RngInterface from '../../tools/rng/GeneratorInterface';
+import KeypadsReader from './KeypadsReader';
 
 class Pia {
     constructor(
         private _controlPanel: ControlPanelInterface,
         private _joystick0: DigitalJoystickInterface,
         private _joystick1: DigitalJoystickInterface,
+        private _keypads: KeypadsReader,
         private _rng?: RngInterface
     ) {
         this.reset();
@@ -112,7 +114,16 @@ class Pia {
         return this;
     }
 
-    private _writeIo(address: number, value: number): void {}
+    private _writeIo(address: number, value: number): void {
+        switch (address) {
+            case Pia.Registers.swcha:
+                this._keypads.swcha(value);
+                break;
+            case Pia.Registers.swacnt:
+                this._keypads.swacnt(value);
+                break;
+        }
+    }
 
     private _writeTimer(address: number, value: number): void {
         this._interruptFlag = 0;
@@ -237,7 +248,7 @@ namespace Pia {
     }
 
     export class TrapPayload {
-        constructor(public reason: TrapReason, public pia: Pia, public message?: string) {}
+        constructor(public reason: TrapReason, public pia: Pia, public message?: string) { }
     }
 }
 

--- a/src/machine/stella/tia/Tia.ts
+++ b/src/machine/stella/tia/Tia.ts
@@ -222,13 +222,12 @@ class Tia implements VideoOutputInterface {
         const lastDataBusValue = this._bus.getLastDataBusValue();
 
         const usePaddlesPort0 =
-            (this._config.emulatePaddles && (this._config.controllerPort0 == Config.ControllerType.joystick)) ||
             (this._config.controllerPort0 === Config.ControllerType.paddles);
         const usePaddlesPort1 =
-            (this._config.emulatePaddles && (this._config.controllerPort1 == Config.ControllerType.joystick)) ||
             (this._config.controllerPort1 === Config.ControllerType.paddles);
-        const useKeypads =
-            (this._config.controllerPort0 === Config.ControllerType.keypad) ||
+        const useKeypadsPort0 =
+            (this._config.controllerPort0 === Config.ControllerType.keypad);
+        const useKeypadsPort1 =
             (this._config.controllerPort1 === Config.ControllerType.keypad);
 
         let result: number;
@@ -236,27 +235,27 @@ class Tia implements VideoOutputInterface {
         // Only keep the lowest four bits
         switch (address & 0x0f) {
             case Tia.Registers.inpt0:
-                result = (useKeypads ? this._keypads.inpt(0, 0) : 0) | (usePaddlesPort0 ? this._paddles[0].inpt() : 0) | (lastDataBusValue & 0x40);
+                result = (useKeypadsPort0 ? this._keypads.inpt(0, 0) : 0) | (usePaddlesPort0 ? this._paddles[0].inpt() : 0) | (lastDataBusValue & 0x40);
                 break;
 
             case Tia.Registers.inpt1:
-                result = (useKeypads ? this._keypads.inpt(0, 1) : 0) | (usePaddlesPort0 ? this._paddles[1].inpt() : 0) | (lastDataBusValue & 0x40);
+                result = (useKeypadsPort0 ? this._keypads.inpt(0, 1) : 0) | (usePaddlesPort0 ? this._paddles[1].inpt() : 0) | (lastDataBusValue & 0x40);
                 break;
 
             case Tia.Registers.inpt2:
-                result = (useKeypads ? this._keypads.inpt(1, 0) : 0) | (usePaddlesPort1 ? this._paddles[2].inpt() : 0) | (lastDataBusValue & 0x40);
+                result = (useKeypadsPort1 ? this._keypads.inpt(1, 0) : 0) | (usePaddlesPort1 ? this._paddles[2].inpt() : 0) | (lastDataBusValue & 0x40);
                 break;
 
             case Tia.Registers.inpt3:
-                result = (useKeypads ? this._keypads.inpt(1, 1) : 0) | (usePaddlesPort1 ? this._paddles[3].inpt() : 0) | (lastDataBusValue & 0x40);
+                result = (useKeypadsPort1 ? this._keypads.inpt(1, 1) : 0) | (usePaddlesPort1 ? this._paddles[3].inpt() : 0) | (lastDataBusValue & 0x40);
                 break;
 
             case Tia.Registers.inpt4:
-                result = (useKeypads ? this._keypads.inpt(0, 2) : this._input0.inpt()) | (lastDataBusValue & 0x40);
+                result = (useKeypadsPort0 ? this._keypads.inpt(0, 2) : this._input0.inpt()) | (lastDataBusValue & 0x40);
                 break;
 
             case Tia.Registers.inpt5:
-                result = (useKeypads ? this._keypads.inpt(1, 2) : this._input1.inpt()) | (lastDataBusValue & 0x40);
+                result = (useKeypadsPort1 ? this._keypads.inpt(1, 2) : this._input1.inpt()) | (lastDataBusValue & 0x40);
                 break;
 
             case Tia.Registers.cxm0p:

--- a/src/machine/stella/tia/Tia.ts
+++ b/src/machine/stella/tia/Tia.ts
@@ -236,27 +236,27 @@ class Tia implements VideoOutputInterface {
         // Only keep the lowest four bits
         switch (address & 0x0f) {
             case Tia.Registers.inpt0:
-                result = (useKeypads ? this._keypads.inpt(0) : 0) | (usePaddlesPort0 ? this._paddles[0].inpt() : 0) | (lastDataBusValue & 0x40);
+                result = (useKeypads ? this._keypads.inpt(0, 0) : 0) | (usePaddlesPort0 ? this._paddles[0].inpt() : 0) | (lastDataBusValue & 0x40);
                 break;
 
             case Tia.Registers.inpt1:
-                result = (useKeypads ? this._keypads.inpt(1) : 0) | (usePaddlesPort0 ? this._paddles[1].inpt() : 0) | (lastDataBusValue & 0x40);
+                result = (useKeypads ? this._keypads.inpt(0, 1) : 0) | (usePaddlesPort0 ? this._paddles[1].inpt() : 0) | (lastDataBusValue & 0x40);
                 break;
 
             case Tia.Registers.inpt2:
-                result = (usePaddlesPort1 ? this._paddles[2].inpt() : 0) | (lastDataBusValue & 0x40);
+                result = (useKeypads ? this._keypads.inpt(1, 0) : 0) | (usePaddlesPort1 ? this._paddles[2].inpt() : 0) | (lastDataBusValue & 0x40);
                 break;
 
             case Tia.Registers.inpt3:
-                result = (usePaddlesPort1 ? this._paddles[3].inpt() : 0) | (lastDataBusValue & 0x40);
+                result = (useKeypads ? this._keypads.inpt(1, 1) : 0) | (usePaddlesPort1 ? this._paddles[3].inpt() : 0) | (lastDataBusValue & 0x40);
                 break;
 
             case Tia.Registers.inpt4:
-                result = (useKeypads ? this._keypads.inpt(2) : this._input0.inpt()) | (lastDataBusValue & 0x40);
+                result = (useKeypads ? this._keypads.inpt(0, 2) : this._input0.inpt()) | (lastDataBusValue & 0x40);
                 break;
 
             case Tia.Registers.inpt5:
-                result = this._input1.inpt() | (lastDataBusValue & 0x40);
+                result = (useKeypads ? this._keypads.inpt(1, 2) : this._input1.inpt()) | (lastDataBusValue & 0x40);
                 break;
 
             case Tia.Registers.cxm0p:

--- a/src/machine/stella/tia/Tia.ts
+++ b/src/machine/stella/tia/Tia.ts
@@ -221,28 +221,36 @@ class Tia implements VideoOutputInterface {
     read(address: number): number {
         const lastDataBusValue = this._bus.getLastDataBusValue();
 
+        const usePaddlesPort0 =
+            this._config.emulatePaddles || (this._config.controllerPort0 === Config.ControllerType.paddles);
+        const usePaddlesPort1 =
+            this._config.emulatePaddles || (this._config.controllerPort1 === Config.ControllerType.paddles);
+        const useKeypads =
+            (this._config.controllerPort0 === Config.ControllerType.keypad) ||
+            (this._config.controllerPort1 === Config.ControllerType.keypad);
+
         let result: number;
 
         // Only keep the lowest four bits
         switch (address & 0x0f) {
             case Tia.Registers.inpt0:
-                result = this._keypads.inpt(0) | (this._config.emulatePaddles ? this._paddles[0].inpt() : 0) | (lastDataBusValue & 0x40);
+                result = (useKeypads ? this._keypads.inpt(0) : 0) | (usePaddlesPort0 ? this._paddles[0].inpt() : 0) | (lastDataBusValue & 0x40);
                 break;
 
             case Tia.Registers.inpt1:
-                result = this._keypads.inpt(1) | (this._config.emulatePaddles ? this._paddles[1].inpt() : 0) | (lastDataBusValue & 0x40);
+                result = (useKeypads ? this._keypads.inpt(1) : 0) | (usePaddlesPort0 ? this._paddles[1].inpt() : 0) | (lastDataBusValue & 0x40);
                 break;
 
             case Tia.Registers.inpt2:
-                result = (this._config.emulatePaddles ? this._paddles[2].inpt() : 0) | (lastDataBusValue & 0x40);
+                result = (usePaddlesPort1 ? this._paddles[2].inpt() : 0) | (lastDataBusValue & 0x40);
                 break;
 
             case Tia.Registers.inpt3:
-                result = (this._config.emulatePaddles ? this._paddles[3].inpt() : 0) | (lastDataBusValue & 0x40);
+                result = (usePaddlesPort1 ? this._paddles[3].inpt() : 0) | (lastDataBusValue & 0x40);
                 break;
 
             case Tia.Registers.inpt4:
-                result = this._keypads.inpt(2) | this._input0.inpt() | (lastDataBusValue & 0x40);
+                result = (useKeypads ? this._keypads.inpt(2) : this._input0.inpt()) | (lastDataBusValue & 0x40);
                 break;
 
             case Tia.Registers.inpt5:

--- a/src/machine/stella/tia/Tia.ts
+++ b/src/machine/stella/tia/Tia.ts
@@ -222,9 +222,11 @@ class Tia implements VideoOutputInterface {
         const lastDataBusValue = this._bus.getLastDataBusValue();
 
         const usePaddlesPort0 =
-            this._config.emulatePaddles || (this._config.controllerPort0 === Config.ControllerType.paddles);
+            (this._config.emulatePaddles && (this._config.controllerPort0 == Config.ControllerType.joystick)) ||
+            (this._config.controllerPort0 === Config.ControllerType.paddles);
         const usePaddlesPort1 =
-            this._config.emulatePaddles || (this._config.controllerPort1 === Config.ControllerType.paddles);
+            (this._config.emulatePaddles && (this._config.controllerPort1 == Config.ControllerType.joystick)) ||
+            (this._config.controllerPort1 === Config.ControllerType.paddles);
         const useKeypads =
             (this._config.controllerPort0 === Config.ControllerType.keypad) ||
             (this._config.controllerPort1 === Config.ControllerType.keypad);

--- a/src/web/driver/MouseAsPaddle.ts
+++ b/src/web/driver/MouseAsPaddle.ts
@@ -34,7 +34,9 @@ export default class MouseAsPaddleDriver {
         this._paddle = paddle;
         this._x = -1;
 
-        document.addEventListener('mousemove', this._listener);
+        document.addEventListener('mousemove', this._mousemoveListener);
+        document.addEventListener('mousedown', this._mousedownListener);
+        document.addEventListener('mouseup', this._mouseupListener);
     }
 
     unbind(): void {
@@ -42,7 +44,9 @@ export default class MouseAsPaddleDriver {
             return;
         }
 
-        document.removeEventListener('mousemove', this._listener);
+        document.removeEventListener('mousemove', this._mousemoveListener);
+        document.removeEventListener('mousedown', this._mousedownListener);
+        document.removeEventListener('mouseup', this._mouseupListener);
         this._paddle = null;
     }
 
@@ -65,7 +69,17 @@ export default class MouseAsPaddleDriver {
         this._x = e.screenX;
     }
 
+    private _onDocumentMouseDown(e: MouseEvent) {
+        this._paddle.getFire().toggle(true);
+    }
+
+    private _onDocumentMouseUp(e: MouseEvent) {
+        this._paddle.getFire().toggle(false);
+    }
+
     private _paddle: PaddleInterface;
     private _x = -1;
-    private _listener: (e: MouseEvent) => void = this._onDocumentMouseMove.bind(this);
+    private _mousemoveListener: (e: MouseEvent) => void = this._onDocumentMouseMove.bind(this);
+    private _mousedownListener: (e: MouseEvent) => void = this._onDocumentMouseDown.bind(this);
+    private _mouseupListener: (e: MouseEvent) => void = this._onDocumentMouseUp.bind(this);
 }

--- a/src/web/embedded/stellerator/Stellerator.ts
+++ b/src/web/embedded/stellerator/Stellerator.ts
@@ -994,6 +994,9 @@ export namespace Stellerator {
         secam = 'secam',
     }
 
+    /**
+     * Controller types
+     */
     export enum ControllerType {
         /**
          * Joystick

--- a/src/web/embedded/stellerator/Stellerator.ts
+++ b/src/web/embedded/stellerator/Stellerator.ts
@@ -571,7 +571,12 @@ export class Stellerator {
             this._keyboardIO = new KeyboardIO(this._config.keyboardTarget);
 
             this._driverManager.addDriver(this._keyboardIO, (context) =>
-                this._keyboardIO.bind(context.getJoystick(0), context.getJoystick(1), context.getControlPanel())
+                this._keyboardIO.bind(
+                    context.getJoystick(0),
+                    context.getJoystick(1),
+                    context.getKeypad(0),
+                    context.getKeypad(1),
+                    context.getControlPanel())
             );
 
             if (this._config.fullscreenViaKeyboard) {

--- a/src/web/embedded/stellerator/Stellerator.ts
+++ b/src/web/embedded/stellerator/Stellerator.ts
@@ -410,10 +410,6 @@ export class Stellerator {
                 stellaConfig.randomSeed = config.randomSeed;
             }
 
-            if (typeof config.emulatePaddles !== 'undefined') {
-                stellaConfig.emulatePaddles = config.emulatePaddles;
-            }
-
             if (typeof config.controllerPort0 !== 'undefined') {
                 stellaConfig.controllerPort0 = this._convertControllerType(config.controllerPort0);
             }
@@ -1072,13 +1068,6 @@ export namespace Stellerator {
          * Default: undefined [automatic]
          */
         randomSeed: number;
-
-        /**
-         * Emulate paddles.
-         *
-         * Default: true
-         */
-        emulatePaddles: boolean;
 
         /**
          * Enable specific controller type for port 0

--- a/src/web/embedded/stellerator/Stellerator.ts
+++ b/src/web/embedded/stellerator/Stellerator.ts
@@ -341,6 +341,20 @@ export class Stellerator {
         return this._controlPanel;
     }
 
+    /**
+     * Trigger a keyboard action by name.
+     */
+    triggerKeydownAction(name: string) {
+        this._keyboardIO.triggerAction(KeyboardIO.Actions[name], true);
+    }
+
+    /**
+     * Trigger a keyboard action by name.
+     */
+    triggerKeyupAction(name: string) {
+        this._keyboardIO.triggerAction(KeyboardIO.Actions[name], false);
+    }
+
     setCanvas(canvas: HTMLCanvasElement): this {
         this._canvasElt = canvas;
 

--- a/src/web/embedded/stellerator/Stellerator.ts
+++ b/src/web/embedded/stellerator/Stellerator.ts
@@ -400,11 +400,27 @@ export class Stellerator {
                 stellaConfig.emulatePaddles = config.emulatePaddles;
             }
 
+            if (typeof config.controllerPort0 !== 'undefined') {
+                stellaConfig.controllerPort0 = this._convertControllerType(config.controllerPort0);
+            }
+
+            if (typeof config.controllerPort1 !== 'undefined') {
+                stellaConfig.controllerPort1 = this._convertControllerType(config.controllerPort1);
+            }
+
             if (typeof config.frameStart !== 'undefined') {
                 stellaConfig.frameStart = config.frameStart;
             }
 
             stellaConfig.cpuType = cpuType(config.cpuAccuracy);
+
+            if (stellaConfig.controllerPort0 === StellaConfig.ControllerType.keypad) {
+                this._keyboardIO.overlay(KeyboardIO.keypad0Mappings);
+            }
+
+            if (stellaConfig.controllerPort1 === StellaConfig.ControllerType.keypad) {
+                this._keyboardIO.overlay(KeyboardIO.keypad1Mappings);
+            }
 
             await this._serviceInitialized;
 
@@ -533,6 +549,22 @@ export class Stellerator {
 
             default:
                 throw new Error(`invalid TV mode '${tvMode}'`);
+        }
+    }
+
+    private _convertControllerType(controllerType: Stellerator.ControllerType): StellaConfig.ControllerType {
+        switch (controllerType) {
+            case Stellerator.ControllerType.joystick:
+                return StellaConfig.ControllerType.joystick;
+
+            case Stellerator.ControllerType.paddles:
+                return StellaConfig.ControllerType.paddles;
+
+            case Stellerator.ControllerType.keypad:
+                return StellaConfig.ControllerType.keypad;
+
+            default:
+                throw new Error(`invalid controller type '${controllerType}'`);
         }
     }
 
@@ -952,6 +984,21 @@ export namespace Stellerator {
         secam = 'secam',
     }
 
+    export enum ControllerType {
+        /**
+         * Joystick
+         */
+        joystick = 'joystick',
+        /**
+         * PAL
+         */
+        paddles = 'paddles',
+        /**
+         * SECAM
+         */
+        keypad = 'keypad',
+    }
+
     /**
      * TV emulation modes. Enabling TV emulation may cause visual artifacts on some
      * (ancient) GPUs
@@ -1018,6 +1065,20 @@ export namespace Stellerator {
          * Default: true
          */
         emulatePaddles: boolean;
+
+        /**
+         * Enable specific controller type for port 0
+         *
+         * Default: true
+         */
+        controllerPort0: ControllerType;
+
+        /**
+         * Enable specific controllers
+         *
+         * Default: true
+         */
+        controllerPort1: ControllerType;
 
         /**
          * The first visible scanline of the frame. The default is autodetection, which

--- a/src/web/stella/driver/KeyboardIO.ts
+++ b/src/web/stella/driver/KeyboardIO.ts
@@ -106,19 +106,7 @@ class KeyboardIO {
 
             if (typeof action !== 'undefined') {
                 e.preventDefault();
-
-                const dispatch = this._dispatchTable[action];
-                switch (dispatch.type) {
-                    case DispatchType.swtch:
-                        dispatch.swtch.toggle(true);
-                        break;
-
-                    case DispatchType.triggerDown:
-                        dispatch.trigger.dispatch(undefined);
-                        break;
-
-                    default:
-                }
+                this.triggerAction(action, true);
             }
         };
 
@@ -129,21 +117,31 @@ class KeyboardIO {
 
             for (const action of this._compiledMappings.get(e.keyCode).values()) {
                 e.preventDefault();
-
-                const dispatch = this._dispatchTable[action];
-
-                switch (dispatch.type) {
-                    case DispatchType.swtch:
-                        dispatch.swtch.toggle(false);
-                        break;
-
-                    default:
-                }
+                this.triggerAction(action, false);
             }
         };
 
         this._target.addEventListener('keydown', this._keydownListener);
         this._target.addEventListener('keyup', this._keyupListener);
+    }
+
+    triggerAction(action: KeyboardIO.Action, position: boolean): void {
+        const dispatch = this._dispatchTable[action];
+        if (dispatch) {
+            switch (dispatch.type) {
+                case DispatchType.swtch:
+                    dispatch.swtch.toggle(position);
+                    break;
+
+                case DispatchType.triggerDown:
+                    if (position) {
+                        dispatch.trigger.dispatch(undefined);
+                    }
+                    break;
+
+                default:
+            }
+        }
     }
 
     overlay(mappings: Array<KeyboardIO.Mapping>): void {
@@ -246,6 +244,7 @@ class KeyboardIO {
 
     private _dispatchTable: { [action: number]: Dispatch } = {};
     private _compiledMappings = new Map<number, Map<number, KeyboardIO.Action>>();
+
 }
 
 namespace KeyboardIO {
@@ -292,6 +291,48 @@ namespace KeyboardIO {
         fullscreen,
         hardReset,
         togglePause
+    }
+
+    export const Actions: Record<string, Action> = {
+        'select': Action.select,
+        'reset': Action.reset,
+        'left0': Action.left0,
+        'right0': Action.right0,
+        'up0': Action.up0,
+        'down0': Action.down0,
+        'left1': Action.left1,
+        'right1': Action.right1,
+        'up1': Action.up1,
+        'down1': Action.down1,
+        'fire0': Action.fire0,
+        'fire1': Action.fire1,
+        'keypad0r0c0': Action.keypad0r0c0,
+        'keypad0r0c1': Action.keypad0r0c1,
+        'keypad0r0c2': Action.keypad0r0c2,
+        'keypad0r1c0': Action.keypad0r1c0,
+        'keypad0r1c1': Action.keypad0r1c1,
+        'keypad0r1c2': Action.keypad0r1c2,
+        'keypad0r2c0': Action.keypad0r2c0,
+        'keypad0r2c1': Action.keypad0r2c1,
+        'keypad0r2c2': Action.keypad0r2c2,
+        'keypad0r3c0': Action.keypad0r3c0,
+        'keypad0r3c1': Action.keypad0r3c1,
+        'keypad0r3c2': Action.keypad0r3c2,
+        'keypad1r0c0': Action.keypad1r0c0,
+        'keypad1r0c1': Action.keypad1r0c1,
+        'keypad1r0c2': Action.keypad1r0c2,
+        'keypad1r1c0': Action.keypad1r1c0,
+        'keypad1r1c1': Action.keypad1r1c1,
+        'keypad1r1c2': Action.keypad1r1c2,
+        'keypad1r2c0': Action.keypad1r2c0,
+        'keypad1r2c1': Action.keypad1r2c1,
+        'keypad1r2c2': Action.keypad1r2c2,
+        'keypad1r3c0': Action.keypad1r3c0,
+        'keypad1r3c1': Action.keypad1r3c1,
+        'keypad1r3c2': Action.keypad1r3c2,
+        'fullscreen': Action.fullscreen,
+        'hardReset': Action.hardReset,
+        'togglePause': Action.togglePause,
     }
 
     export const enum Modifier {
@@ -502,5 +543,6 @@ namespace KeyboardIO {
     ];
 
 }
+
 
 export { KeyboardIO as default };

--- a/src/web/stella/driver/KeyboardIO.ts
+++ b/src/web/stella/driver/KeyboardIO.ts
@@ -67,7 +67,7 @@ class KeyboardIO {
         // tslint:disable-next-line
         mappings: Array<KeyboardIO.Mapping> = KeyboardIO.defaultMappings
     ) {
-        this._compileMappings(mappings, false);
+        this._compileMappings(mappings);
     }
 
     bind(
@@ -147,7 +147,7 @@ class KeyboardIO {
     }
 
     overlay(mappings: Array<KeyboardIO.Mapping>): void {
-        this._compileMappings(mappings, true);
+        this._compileMappings(mappings);
     }
 
     unbind(): void {
@@ -158,7 +158,7 @@ class KeyboardIO {
         this._target.removeEventListener('keydown', this._keydownListener);
         this._target.removeEventListener('keyup', this._keyupListener);
 
-        this._joystick0 = this._joystick1 = this._controlPanel = null;
+        this._joystick0 = this._joystick1 = this._keypad0 = this._keypad1 = this._controlPanel = null;
         this._keydownListener = this._keyupListener = null;
     }
 
@@ -204,13 +204,13 @@ class KeyboardIO {
         this._dispatchTable[KeyboardIO.Action.keypad1r3c2] = mkSwitch(this._keypad1.getKey(3, 2));
     }
 
-    private _compileMappings(mappings: Array<KeyboardIO.Mapping>, overwrite: boolean = false): void {
+    private _compileMappings(mappings: Array<KeyboardIO.Mapping>): void {
         const compileMapping = (action: KeyboardIO.Action, keycode: number, modifiers: number) => {
             if ((modifiers & ~(KeyboardIO.Modifier.shift | KeyboardIO.Modifier.ctrl | KeyboardIO.Modifier.alt)) !== 0) {
                 throw new Error(`invalid modifier set ${modifiers}`);
             }
 
-            if (overwrite || !this._compiledMappings.has(keycode)) {
+            if (!this._compiledMappings.has(keycode)) {
                 this._compiledMappings.set(keycode, new Map<number, KeyboardIO.Action>());
             }
 

--- a/src/web/stella/driver/KeyboardIO.ts
+++ b/src/web/stella/driver/KeyboardIO.ts
@@ -494,51 +494,51 @@ namespace KeyboardIO {
     export const keypad1Mappings: Array<Mapping> = [
         {
             action: Action.keypad1r0c0,
-            spec: 56// 8
+            spec: 55// 7
         },
         {
             action: Action.keypad1r0c1,
-            spec: 57 // 9
+            spec: 56// 8
         },
         {
             action: Action.keypad1r0c2,
-            spec: 48 // 0
+            spec: 57 // 9
         },
         {
             action: Action.keypad1r1c0,
-            spec: 73 // i
+            spec: 85 // u
         },
         {
             action: Action.keypad1r1c1,
-            spec: 79 // o
+            spec: 73 // i
         },
         {
             action: Action.keypad1r1c2,
-            spec: 80 // p
+            spec: 79 // o
         },
         {
             action: Action.keypad1r2c0,
-            spec: 75 // k
+            spec: 74 // j
         },
         {
             action: Action.keypad1r2c1,
-            spec: 76 // l
+            spec: 75 // k
         },
         {
             action: Action.keypad1r2c2,
-            spec: 186 // ;
+            spec: 76 // l
         },
         {
             action: Action.keypad1r3c0,
-            spec: 188 // ,
+            spec: 77 // m
         },
         {
             action: Action.keypad1r3c1,
-            spec: 190 // .
+            spec: 188 // ,
         },
         {
             action: Action.keypad1r3c2,
-            spec: 191 // /
+            spec: 190 // .
         }
     ];
 

--- a/src/web/stella/driver/KeyboardIO.ts
+++ b/src/web/stella/driver/KeyboardIO.ts
@@ -28,6 +28,7 @@ import { Event } from 'microevent.ts';
 import SwitchInterface from '../../../machine/io/SwitchInterface';
 import JoystickInterface from '../../../machine/io/DigitalJoystickInterface';
 import ControlPanelInterface from '../../../machine/stella/ControlPanelInterface';
+import KeypadControllerInterface from '../../../machine/io/KeypadControllerInterface';
 
 const enum DispatchType {
     swtch,
@@ -69,13 +70,20 @@ class KeyboardIO {
         this._compileMappings(mappings);
     }
 
-    bind(joystick0: JoystickInterface, joystick1: JoystickInterface, controlPanel: ControlPanelInterface): void {
+    bind(
+        joystick0: JoystickInterface,
+        joystick1: JoystickInterface,
+        keypad0: KeypadControllerInterface,
+        keypad1: KeypadControllerInterface,
+        controlPanel: ControlPanelInterface): void {
         if (this._joystick0) {
             return;
         }
 
         this._joystick0 = joystick0;
         this._joystick1 = joystick1;
+        this._keypad0 = keypad0;
+        this._keypad1 = keypad1;
         this._controlPanel = controlPanel;
 
         this._updateActionTable();
@@ -166,6 +174,30 @@ class KeyboardIO {
         this._dispatchTable[KeyboardIO.Action.up1] = mkSwitch(this._joystick1.getUp());
         this._dispatchTable[KeyboardIO.Action.down1] = mkSwitch(this._joystick1.getDown());
         this._dispatchTable[KeyboardIO.Action.fire1] = mkSwitch(this._joystick1.getFire());
+        this._dispatchTable[KeyboardIO.Action.keypad0r0c0] = mkSwitch(this._keypad0.getKey(0, 0));
+        this._dispatchTable[KeyboardIO.Action.keypad0r0c1] = mkSwitch(this._keypad0.getKey(0, 1));
+        this._dispatchTable[KeyboardIO.Action.keypad0r0c2] = mkSwitch(this._keypad0.getKey(0, 2));
+        this._dispatchTable[KeyboardIO.Action.keypad0r1c0] = mkSwitch(this._keypad0.getKey(1, 0));
+        this._dispatchTable[KeyboardIO.Action.keypad0r1c1] = mkSwitch(this._keypad0.getKey(1, 1));
+        this._dispatchTable[KeyboardIO.Action.keypad0r1c2] = mkSwitch(this._keypad0.getKey(1, 2));
+        this._dispatchTable[KeyboardIO.Action.keypad0r2c0] = mkSwitch(this._keypad0.getKey(2, 0));
+        this._dispatchTable[KeyboardIO.Action.keypad0r2c1] = mkSwitch(this._keypad0.getKey(2, 1));
+        this._dispatchTable[KeyboardIO.Action.keypad0r2c2] = mkSwitch(this._keypad0.getKey(2, 2));
+        this._dispatchTable[KeyboardIO.Action.keypad0r3c0] = mkSwitch(this._keypad0.getKey(3, 0));
+        this._dispatchTable[KeyboardIO.Action.keypad0r3c1] = mkSwitch(this._keypad0.getKey(3, 1));
+        this._dispatchTable[KeyboardIO.Action.keypad0r3c2] = mkSwitch(this._keypad0.getKey(3, 2));
+        this._dispatchTable[KeyboardIO.Action.keypad1r0c0] = mkSwitch(this._keypad1.getKey(0, 0));
+        this._dispatchTable[KeyboardIO.Action.keypad1r0c1] = mkSwitch(this._keypad1.getKey(0, 1));
+        this._dispatchTable[KeyboardIO.Action.keypad1r0c2] = mkSwitch(this._keypad1.getKey(0, 2));
+        this._dispatchTable[KeyboardIO.Action.keypad1r1c0] = mkSwitch(this._keypad1.getKey(1, 0));
+        this._dispatchTable[KeyboardIO.Action.keypad1r1c1] = mkSwitch(this._keypad1.getKey(1, 1));
+        this._dispatchTable[KeyboardIO.Action.keypad1r1c2] = mkSwitch(this._keypad1.getKey(1, 2));
+        this._dispatchTable[KeyboardIO.Action.keypad1r2c0] = mkSwitch(this._keypad1.getKey(2, 0));
+        this._dispatchTable[KeyboardIO.Action.keypad1r2c1] = mkSwitch(this._keypad1.getKey(2, 1));
+        this._dispatchTable[KeyboardIO.Action.keypad1r2c2] = mkSwitch(this._keypad1.getKey(2, 2));
+        this._dispatchTable[KeyboardIO.Action.keypad1r3c0] = mkSwitch(this._keypad1.getKey(3, 0));
+        this._dispatchTable[KeyboardIO.Action.keypad1r3c1] = mkSwitch(this._keypad1.getKey(3, 1));
+        this._dispatchTable[KeyboardIO.Action.keypad1r3c2] = mkSwitch(this._keypad1.getKey(3, 2));
     }
 
     private _compileMappings(mappings: Array<KeyboardIO.Mapping>): void {
@@ -204,6 +236,8 @@ class KeyboardIO {
 
     private _joystick0: JoystickInterface = null;
     private _joystick1: JoystickInterface = null;
+    private _keypad0: KeypadControllerInterface = null;
+    private _keypad1: KeypadControllerInterface = null;
     private _controlPanel: ControlPanelInterface = null;
 
     private _dispatchTable: { [action: number]: Dispatch } = {};
@@ -224,6 +258,32 @@ namespace KeyboardIO {
         down1,
         fire0,
         fire1,
+
+        keypad0r0c0,
+        keypad0r0c1,
+        keypad0r0c2,
+        keypad0r1c0,
+        keypad0r1c1,
+        keypad0r1c2,
+        keypad0r2c0,
+        keypad0r2c1,
+        keypad0r2c2,
+        keypad0r3c0,
+        keypad0r3c1,
+        keypad0r3c2,
+
+        keypad1r0c0,
+        keypad1r0c1,
+        keypad1r0c2,
+        keypad1r1c0,
+        keypad1r1c1,
+        keypad1r1c2,
+        keypad1r2c0,
+        keypad1r2c1,
+        keypad1r2c2,
+        keypad1r3c0,
+        keypad1r3c1,
+        keypad1r3c2,
 
         fullscreen,
         hardReset,
@@ -266,7 +326,7 @@ namespace KeyboardIO {
         {
             action: Action.left0,
             spec: [
-                65, // w
+                65, // a
                 37 // left
             ]
         },
@@ -334,6 +394,135 @@ namespace KeyboardIO {
             spec: 80 // p
         }
     ];
+
+    export const keypadMappings: Array<Mapping> = [
+        {
+            action: Action.select,
+            spec: {
+                keycode: 32, // space
+                modifiers: Modifier.shift
+            }
+        },
+        {
+            action: Action.reset,
+            spec: {
+                keycode: 13, // enter
+                modifiers: Modifier.shift
+            }
+        },
+        {
+            action: Action.keypad0r0c0,
+            spec: 49 // 0
+        },
+        {
+            action: Action.keypad0r0c1,
+            spec: 50 // 1
+        },
+        {
+            action: Action.keypad0r0c2,
+            spec: 51 // 2
+        },
+        {
+            action: Action.keypad0r1c0,
+            spec: 81 // q
+        },
+        {
+            action: Action.keypad0r1c1,
+            spec: 87 // w
+        },
+        {
+            action: Action.keypad0r1c2,
+            spec: 69 // e
+        },
+        {
+            action: Action.keypad0r2c0,
+            spec: 65 // a
+        },
+        {
+            action: Action.keypad0r2c1,
+            spec: 83 // s
+        },
+        {
+            action: Action.keypad0r2c2,
+            spec: 68 // d
+        },
+        {
+            action: Action.keypad0r3c0,
+            spec: 90 // z
+        },
+        {
+            action: Action.keypad0r3c1,
+            spec: 88 // x
+        },
+        {
+            action: Action.keypad0r3c2,
+            spec: 67 // c
+        },
+        {
+            action: Action.keypad1r0c0,
+            spec: 56// 8
+        },
+        {
+            action: Action.keypad1r0c1,
+            spec: 57 // 9
+        },
+        {
+            action: Action.keypad1r0c2,
+            spec: 48 // 0
+        },
+        {
+            action: Action.keypad1r1c0,
+            spec: 73 // i
+        },
+        {
+            action: Action.keypad1r1c1,
+            spec: 79 // o
+        },
+        {
+            action: Action.keypad1r1c2,
+            spec: 80 // p
+        },
+        {
+            action: Action.keypad1r2c0,
+            spec: 75 // k
+        },
+        {
+            action: Action.keypad1r2c1,
+            spec: 76 // l
+        },
+        {
+            action: Action.keypad1r2c2,
+            spec: 186 // ;
+        },
+        {
+            action: Action.keypad1r3c0,
+            spec: 188 // ,
+        },
+        {
+            action: Action.keypad1r3c1,
+            spec: 190 // .
+        },
+        {
+            action: Action.keypad1r3c2,
+            spec: 191 // /
+        },
+        {
+            action: Action.fullscreen,
+            spec: 13 // enter
+        },
+        {
+            action: Action.hardReset,
+            spec: {
+                keycode: 82, // r
+                modifiers: Modifier.shift
+            }
+        },
+        {
+            action: Action.togglePause,
+            spec: 80 // p
+        }
+    ];
+
 }
 
 export { KeyboardIO as default };

--- a/src/web/stella/driver/KeyboardIO.ts
+++ b/src/web/stella/driver/KeyboardIO.ts
@@ -144,6 +144,11 @@ class KeyboardIO {
         }
     }
 
+    remap(mappings: Array<KeyboardIO.Mapping>): void {
+        this._compiledMappings.clear();
+        this._compileMappings(mappings);
+    }
+
     overlay(mappings: Array<KeyboardIO.Mapping>): void {
         this._compileMappings(mappings);
     }

--- a/src/web/stella/driver/KeyboardIO.ts
+++ b/src/web/stella/driver/KeyboardIO.ts
@@ -67,7 +67,7 @@ class KeyboardIO {
         // tslint:disable-next-line
         mappings: Array<KeyboardIO.Mapping> = KeyboardIO.defaultMappings
     ) {
-        this._compileMappings(mappings);
+        this._compileMappings(mappings, false);
     }
 
     bind(
@@ -146,6 +146,10 @@ class KeyboardIO {
         this._target.addEventListener('keyup', this._keyupListener);
     }
 
+    overlay(mappings: Array<KeyboardIO.Mapping>): void {
+        this._compileMappings(mappings, true);
+    }
+
     unbind(): void {
         if (!this._joystick0) {
             return;
@@ -200,13 +204,13 @@ class KeyboardIO {
         this._dispatchTable[KeyboardIO.Action.keypad1r3c2] = mkSwitch(this._keypad1.getKey(3, 2));
     }
 
-    private _compileMappings(mappings: Array<KeyboardIO.Mapping>): void {
+    private _compileMappings(mappings: Array<KeyboardIO.Mapping>, overwrite: boolean = false): void {
         const compileMapping = (action: KeyboardIO.Action, keycode: number, modifiers: number) => {
             if ((modifiers & ~(KeyboardIO.Modifier.shift | KeyboardIO.Modifier.ctrl | KeyboardIO.Modifier.alt)) !== 0) {
                 throw new Error(`invalid modifier set ${modifiers}`);
             }
 
-            if (!this._compiledMappings.has(keycode)) {
+            if (overwrite || !this._compiledMappings.has(keycode)) {
                 this._compiledMappings.set(keycode, new Map<number, KeyboardIO.Action>());
             }
 
@@ -395,32 +399,18 @@ namespace KeyboardIO {
         }
     ];
 
-    export const keypadMappings: Array<Mapping> = [
-        {
-            action: Action.select,
-            spec: {
-                keycode: 32, // space
-                modifiers: Modifier.shift
-            }
-        },
-        {
-            action: Action.reset,
-            spec: {
-                keycode: 13, // enter
-                modifiers: Modifier.shift
-            }
-        },
+    export const keypad0Mappings: Array<Mapping> = [
         {
             action: Action.keypad0r0c0,
-            spec: 49 // 0
+            spec: 49 // 1
         },
         {
             action: Action.keypad0r0c1,
-            spec: 50 // 1
+            spec: 50 // 2
         },
         {
             action: Action.keypad0r0c2,
-            spec: 51 // 2
+            spec: 51 // 3
         },
         {
             action: Action.keypad0r1c0,
@@ -457,7 +447,10 @@ namespace KeyboardIO {
         {
             action: Action.keypad0r3c2,
             spec: 67 // c
-        },
+        }
+    ];
+
+    export const keypad1Mappings: Array<Mapping> = [
         {
             action: Action.keypad1r0c0,
             spec: 56// 8
@@ -505,21 +498,6 @@ namespace KeyboardIO {
         {
             action: Action.keypad1r3c2,
             spec: 191 // /
-        },
-        {
-            action: Action.fullscreen,
-            spec: 13 // enter
-        },
-        {
-            action: Action.hardReset,
-            spec: {
-                keycode: 82, // r
-                modifiers: Modifier.shift
-            }
-        },
-        {
-            action: Action.togglePause,
-            spec: 80 // p
         }
     ];
 

--- a/src/web/stella/service/EmulationContextInterface.ts
+++ b/src/web/stella/service/EmulationContextInterface.ts
@@ -31,7 +31,6 @@ import WaveformAudioOutputInterface from '../../../machine/io/WaveformAudioOutpu
 import PCMAudioEndpointInterface from '../../driver/PCMAudioEndpointInterface';
 import Config from '../../../machine/stella/Config';
 import AsyncIOInterface from '../../../machine/io/AsyncIOInterface';
-
 interface EmulationContextInterface {
     getConfig(): Config;
 

--- a/src/web/stella/service/EmulationContextInterface.ts
+++ b/src/web/stella/service/EmulationContextInterface.ts
@@ -31,12 +31,15 @@ import WaveformAudioOutputInterface from '../../../machine/io/WaveformAudioOutpu
 import PCMAudioEndpointInterface from '../../driver/PCMAudioEndpointInterface';
 import Config from '../../../machine/stella/Config';
 import AsyncIOInterface from '../../../machine/io/AsyncIOInterface';
+import KeypadControllerInterface from '../../../machine/io/KeypadControllerInterface';
 interface EmulationContextInterface {
     getConfig(): Config;
 
     getVideo(): VideoEndpointInterface;
 
     getJoystick(i: number): JoystickInterface;
+
+    getKeypad(i: number): KeypadControllerInterface;
 
     getControlPanel(): ControlPanelInterface;
 

--- a/src/web/stella/service/EmulationServiceInterface.ts
+++ b/src/web/stella/service/EmulationServiceInterface.ts
@@ -46,6 +46,10 @@ interface EmulationServiceInterface {
 
     reset(): Promise<EmulationServiceInterface.State>;
 
+    peek(index: number): Promise<number>;
+
+    poke(index: number, value: number): Promise<void>;
+
     setRateLimit(enforce: boolean): Promise<void>;
 
     getRateLimit(): boolean;

--- a/src/web/stella/service/vanilla/EmulationContext.ts
+++ b/src/web/stella/service/vanilla/EmulationContext.ts
@@ -36,9 +36,10 @@ import WaveformAudioOutputInterface from '../../../../machine/io/WaveformAudioOu
 import PCMAudioEndpointInterface from '../../../driver/PCMAudioEndpointInterface';
 import PCMAudioEndpoint from '../../../driver/PCMAudioEndpoint';
 import AsyncIOInterface from '../../../../machine/io/AsyncIOInterface';
+import KeypadControllerInterface from '../../../../machine/io/KeypadControllerInterface';
 
 export default class EmulationContext implements EmulationContextInterface {
-    constructor(private _board: Board, private _asyncIO?: AsyncIOInterface) {}
+    constructor(private _board: Board, private _asyncIO?: AsyncIOInterface) { }
 
     getConfig(): Config {
         return this._board.getConfig();
@@ -62,6 +63,19 @@ export default class EmulationContext implements EmulationContextInterface {
 
             default:
                 throw new Error(`invalid joystick index ${i}`);
+        }
+    }
+
+    getKeypad(i: number): KeypadControllerInterface {
+        switch (i) {
+            case 0:
+                return this._board.getKeypad0();
+
+            case 1:
+                return this._board.getKeypad1();
+
+            default:
+                throw new Error(`invalid keypad index ${i}`);
         }
     }
 

--- a/src/web/stella/service/vanilla/EmulationService.ts
+++ b/src/web/stella/service/vanilla/EmulationService.ts
@@ -168,6 +168,10 @@ export default class EmulationService implements EmulationServiceInterface {
         }
     }
 
+    getBoard(): Board {
+        return this._board;
+    }
+
     getLastError(): Error {
         return this._lastError;
     }
@@ -176,10 +180,21 @@ export default class EmulationService implements EmulationServiceInterface {
         return this._clockProbe.getFrequency();
     }
 
+    peek(index: number): Promise<number> {
+        return this._mutex.runExclusive(() => {
+            return this._board.getBus().peek(index);
+        });
+    }
+
+    poke(index: number, value: number): Promise<void> {
+        return this._mutex.runExclusive(() => {
+            this._board.getBus().poke(index, value);
+        });
+    }
+
     getRateLimit(): boolean {
         return this._enforceRateLimit;
     }
-
     setRateLimit(enforce: boolean): Promise<void> {
         if (this._enforceRateLimit === enforce) {
             return Promise.resolve(undefined);

--- a/src/web/stella/service/worker/ControlDriver.ts
+++ b/src/web/stella/service/worker/ControlDriver.ts
@@ -31,9 +31,10 @@ import PaddleInterface from '../../../../machine/io/PaddleInterface';
 import ControlPanelInterface from '../../../../machine/stella/ControlPanelInterface';
 
 import { SIGNAL_TYPE } from './messages';
+import KeypadControllerInterface from '../../../../machine/io/KeypadControllerInterface';
 
 class ControlDriver {
-    constructor(private _rpc: RpcProviderInterface) {}
+    constructor(private _rpc: RpcProviderInterface) { }
 
     init(): void {
         this._rpc.registerSignalHandler(SIGNAL_TYPE.controlStateUpdate, this._onControlStateUpdate.bind(this));
@@ -66,6 +67,10 @@ class ControlDriver {
             this._applyJoystickState(controlState.joystickState[i], this._emulationContext.getJoystick(i));
         }
 
+        for (let i = 0; i < 2; i++) {
+            this._applyKeypadState(controlState.keypadState[i], this._emulationContext.getKeypad(i));
+        }
+
         for (let i = 0; i < 4; i++) {
             this._applyPaddleState(controlState.paddleState[i], this._emulationContext.getPaddle(i));
         }
@@ -79,6 +84,14 @@ class ControlDriver {
         joystick.getLeft().toggle(state.left);
         joystick.getRight().toggle(state.right);
         joystick.getFire().toggle(state.fire);
+    }
+
+    private _applyKeypadState(state: ControlState.KeypadState, keypad: KeypadControllerInterface): void {
+        for (var row = 0; row < 4; row++) {
+            for (var col = 0; col < 3; col++) {
+                keypad.getKey(row, col).toggle(state.rows[row][col]);
+            }
+        }
     }
 
     private _applyPaddleState(state: ControlState.PaddleState, paddle: PaddleInterface): void {

--- a/src/web/stella/service/worker/ControlProxy.ts
+++ b/src/web/stella/service/worker/ControlProxy.ts
@@ -30,11 +30,16 @@ import ControlState from './ControlState';
 import { RpcProviderInterface } from 'worker-rpc';
 
 import { SIGNAL_TYPE } from './messages';
+import KeypadController from '../../../../machine/io/KeypadController';
 
 class ControlProxy {
     constructor(private _rpc: RpcProviderInterface) {
         for (let i = 0; i < 2; i++) {
             this._joysticks[i] = new Joystick();
+        }
+
+        for (let i = 0; i < 2; i++) {
+            this._keypads[i] = new KeypadController();
         }
 
         for (let i = 0; i < 4; i++) {
@@ -45,6 +50,7 @@ class ControlProxy {
     sendUpdate(): void {
         this._rpc.signal<ControlState>(SIGNAL_TYPE.controlStateUpdate, {
             joystickState: this._joysticks.map(ControlProxy._joystickState),
+            keypadState: this._keypads.map(ControlProxy._keypadState),
             paddleState: this._paddles.map(ControlProxy._paddleState),
             controlPanelState: ControlProxy._controlPanelState(this._controlPanel)
         });
@@ -56,6 +62,13 @@ class ControlProxy {
         }
 
         return this._joysticks[i];
+    }
+
+    getKeypad(i: number): KeypadController {
+        if (i < 0 || i > 1) {
+            throw new Error(`invalid keypad index ${i}`);
+        }
+        return this._keypads[i];
     }
 
     getControlPanel(): ControlPanel {
@@ -80,6 +93,19 @@ class ControlProxy {
         };
     }
 
+    private static _keypadState(keypad: KeypadController): ControlState.KeypadState {
+        const state = {
+            rows: new Array(4)
+        };
+        for (var row = 0; row < 4; row++) {
+            state.rows = new Array(3);
+            for (var col = 0; col < 3; col++) {
+                state.rows[row][col] = keypad.getKey(row, col).read();
+            }
+        }
+        return state;
+    }
+
     private static _paddleState(paddle: Paddle): ControlState.PaddleState {
         return {
             value: paddle.getValue(),
@@ -99,7 +125,9 @@ class ControlProxy {
 
     private _joysticks = new Array<Joystick>(2);
     private _paddles = new Array<Paddle>(4);
+    private _keypads = new Array<KeypadController>(2);
     private _controlPanel = new ControlPanel();
+
 }
 
 export { ControlProxy as default };

--- a/src/web/stella/service/worker/ControlProxy.ts
+++ b/src/web/stella/service/worker/ControlProxy.ts
@@ -98,7 +98,7 @@ class ControlProxy {
             rows: new Array(4)
         };
         for (var row = 0; row < 4; row++) {
-            state.rows = new Array(3);
+            state.rows[row] = new Array(3);
             for (var col = 0; col < 3; col++) {
                 state.rows[row][col] = keypad.getKey(row, col).read();
             }

--- a/src/web/stella/service/worker/EmulationBackend.ts
+++ b/src/web/stella/service/worker/EmulationBackend.ts
@@ -34,7 +34,7 @@ import PCMAudioDriver from './PCMAudioDriver';
 import EmulationContext from '../vanilla/EmulationContext';
 import AsyncIODriver from '../../../driver/AsyncIO';
 
-import { RPC_TYPE, SIGNAL_TYPE, EmulationStartMessage, SetupMessage, MessageToAsyncIOMessage } from './messages';
+import { RPC_TYPE, SIGNAL_TYPE, EmulationStartMessage, EmulationPokeMessage, SetupMessage, MessageToAsyncIOMessage } from './messages';
 
 class EmulationBackend {
     constructor(private _rpc: RpcProviderInterface) {
@@ -58,6 +58,8 @@ class EmulationBackend {
             .registerRpcHandler(RPC_TYPE.emulationSetRateLimit, this._onEmulationSetRateLimit.bind(this))
             .registerRpcHandler(RPC_TYPE.emulationStart, this._onEmulationStart.bind(this))
             .registerRpcHandler(RPC_TYPE.emulationStop, this._onEmulationStop.bind(this))
+            .registerRpcHandler(RPC_TYPE.emulationPeek, this._onEmulationPeek.bind(this))
+            .registerRpcHandler(RPC_TYPE.emulationPoke, this._onEmulationPoke.bind(this))
             .registerSignalHandler<MessageToAsyncIOMessage>(SIGNAL_TYPE.messageToAsyncIO, data =>
                 asyncIODriver.send(data)
             );
@@ -131,6 +133,14 @@ class EmulationBackend {
 
     private _onEmulationSetRateLimit(message: boolean): Promise<void> {
         return this._service.setRateLimit(message);
+    }
+
+    private _onEmulationPeek(message: number): Promise<number> {
+        return this._service.peek(message);
+    }
+
+    private _onEmulationPoke(message: EmulationPokeMessage): Promise<void> {
+        return this._service.poke(message.index, message.value);
     }
 
     private _service: EmulationService;

--- a/src/web/stella/service/worker/EmulationContext.ts
+++ b/src/web/stella/service/worker/EmulationContext.ts
@@ -37,7 +37,6 @@ import ControlProxy from './ControlProxy';
 import WaveformAudioProxy from './WaveformAudioProxy';
 import PCMAudioProxy from './PCMAudioProxy';
 import AsyncIOProxy from './AsyncIOProxy';
-
 class EmulationContext implements EmulationContextInterface {
     constructor(
         private _videoProxy: VideoProxy,

--- a/src/web/stella/service/worker/EmulationContext.ts
+++ b/src/web/stella/service/worker/EmulationContext.ts
@@ -37,6 +37,7 @@ import ControlProxy from './ControlProxy';
 import WaveformAudioProxy from './WaveformAudioProxy';
 import PCMAudioProxy from './PCMAudioProxy';
 import AsyncIOProxy from './AsyncIOProxy';
+import KeypadControllerInterface from '../../../../machine/io/KeypadControllerInterface';
 class EmulationContext implements EmulationContextInterface {
     constructor(
         private _videoProxy: VideoProxy,
@@ -64,6 +65,10 @@ class EmulationContext implements EmulationContextInterface {
 
     getJoystick(i: number): JoystickInterface {
         return this._controlProxy.getJoystick(i);
+    }
+
+    getKeypad(i: number): KeypadControllerInterface {
+        return this._controlProxy.getKeypad(i);
     }
 
     getControlPanel(): ControlPanelInterface {

--- a/src/web/stella/service/worker/EmulationService.ts
+++ b/src/web/stella/service/worker/EmulationService.ts
@@ -38,7 +38,7 @@ import CartridgeInfo from '../../../../machine/stella/cartridge/CartridgeInfo';
 
 import { Mutex } from 'async-mutex';
 
-import { RPC_TYPE, SIGNAL_TYPE, EmulationStartMessage } from './messages';
+import { RPC_TYPE, SIGNAL_TYPE, EmulationStartMessage, EmulationPokeMessage } from './messages';
 import AsyncIOProxy from './AsyncIOProxy';
 
 const CONTROL_PROXY_UPDATE_INTERVAL = 25;
@@ -172,7 +172,7 @@ class EmulationService implements EmulationServiceInterface {
     }
 
     poke(index: number, value: number): Promise<void> {
-        return this._rpc.rpc<number, void>(RPC_TYPE.emulationPoke, index, value);
+        return this._rpc.rpc<EmulationPokeMessage, void>(RPC_TYPE.emulationPoke, { index, value });
     }
 
     getFrequency(): number {

--- a/src/web/stella/service/worker/EmulationService.ts
+++ b/src/web/stella/service/worker/EmulationService.ts
@@ -50,7 +50,7 @@ const enum ProxyState {
 }
 
 class EmulationService implements EmulationServiceInterface {
-    constructor(private _stellaWorkerUri: string) {}
+    constructor(private _stellaWorkerUri: string) { }
 
     async init(): Promise<void> {
         this._worker = new Worker(this._stellaWorkerUri);
@@ -165,6 +165,14 @@ class EmulationService implements EmulationServiceInterface {
         this._rateLimitEnforced = enforce;
 
         return this._rpc.rpc<boolean, void>(RPC_TYPE.emulationSetRateLimit, enforce);
+    }
+
+    peek(index: number): Promise<number> {
+        return this._rpc.rpc<number, number>(RPC_TYPE.emulationPeek, index);
+    }
+
+    poke(index: number, value: number): Promise<void> {
+        return this._rpc.rpc<number, void>(RPC_TYPE.emulationPoke, index, value);
     }
 
     getFrequency(): number {

--- a/src/web/stella/service/worker/messages.ts
+++ b/src/web/stella/service/worker/messages.ts
@@ -34,10 +34,12 @@ export const RPC_TYPE = {
     emulationStart: 'emulation/start',
     emulationStop: 'emulation/stop',
     emulationFetchLastError: 'emulation/fetchLastError',
+    emulationPeek: 'emulation/peek',
+    emulationPoke: 'emulation/poke',
     getVideoParameters: 'video/getParameters',
     getWaveformAudioParameters: (index: number) => `audio/waveform/getParameters/${index}`,
     getPCMAudioParameters: (index: number) => `audio/pcm/getParameters/${index}`,
-    setup: '/setup'
+    setup: '/setup',
 };
 Object.freeze(RPC_TYPE);
 
@@ -58,12 +60,17 @@ export const SIGNAL_TYPE = {
 };
 Object.freeze(SIGNAL_TYPE);
 
-export interface SetupMessage {}
+export interface SetupMessage { }
 
 export interface EmulationStartMessage {
     buffer: { [i: number]: number; length: number };
     config: EventServiceInterface.Config;
     cartridgeType?: CartridgeInfo.CartridgeType;
+}
+
+export interface EmulationPokeMessage {
+    index: number;
+    value: number;
 }
 
 export interface VideoParametersResponse {

--- a/tests/Elm/Stellerator/Encoding.elm
+++ b/tests/Elm/Stellerator/Encoding.elm
@@ -38,6 +38,7 @@ import Stellerator.Model
         , Settings
         , TvEmulation(..)
         , TvMode(..)
+        , ControllerType(..)
         , decodeAudioEmulation
         , decodeCartridge
         , decodeCpuEmulation
@@ -68,7 +69,8 @@ suite =
                 , name = "somecart"
                 , cartridgeType = "CDF"
                 , tvMode = TvPAL
-                , emulatePaddles = False
+                , controllerPort0 = ControllerTypeJoystick
+                , controllerPort1 = ControllerTypePaddles
                 , volume = 66
                 , rngSeed = Just 12366
                 , firstVisibleLine = Just 28


### PR DESCRIPTION
This PR adds support for keypad controllers. I have tested this branch in my own embedded stellerator project (https://github.com/dchristianson/vcs-lisp) - there could be be gaps in testing for general use...

TLDR
    * keypad controllers have 12 buttons arranged into 4 rows and 3 columns 
    * only one row can be read at a time for each controller by sending pulses via SWCHA
    * discussion of the controllers + generic test rom here:  https://forums.atariage.com/topic/247615-trying-to-figure-out-keyboard-controllers-inpt/
  
There is an additional change to add peek/poke methods for embedded client, this is used in my current homebrew project to be able to read/write to VCS RAM from outside stellerator

